### PR TITLE
Add Redis Cache resource to Bicep template

### DIFF
--- a/src/InfrastructureAsCode/main.bicep
+++ b/src/InfrastructureAsCode/main.bicep
@@ -13,7 +13,7 @@ var registryName = '${uniqueString(resourceGroup().id)}mpnpreg'
 var registrySku = 'Standard'
 var imageName = 'techexcel/dotnetcoreapp'
 var startupCommand = ''
-
+var redisCacheName = '${uniqueString(resourceGroup().id)}-mpnp-redis'
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-12-01-preview' = {
   name: logAnalyticsName
@@ -28,7 +28,6 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-12
     }
   }
 }
-
 
 resource appInsights 'Microsoft.Insights/components@2020-02-02-preview' = {
   name: appInsightsName
@@ -96,11 +95,24 @@ resource appServiceApp 'Microsoft.Web/sites@2020-12-01' = {
           name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
           value: appInsights.properties.InstrumentationKey
         }
-        ]
-      }
+      ]
     }
+  }
+}
+
+resource redisCache 'Microsoft.Cache/Redis@2021-06-01' = {
+  name: redisCacheName
+  location: location
+  properties: {
+    sku: {
+      name: 'Basic'
+      family: 'C'
+      capacity: 0
+    }
+  }
 }
 
 output application_name string = appServiceApp.name
 output application_url string = appServiceApp.properties.hostNames[0]
 output container_registry_name string = containerRegistry.name
+output redis_cache_name string = redisCache.name


### PR DESCRIPTION
This pull request introduces a new Redis Cache resource to the infrastructure code in `src/InfrastructureAsCode/main.bicep`. The most important changes include adding a new variable for the Redis Cache name, defining the Redis Cache resource, and updating the outputs to include the Redis Cache name.

### Infrastructure Changes:
* Added a new variable `redisCacheName` to store the name of the Redis Cache. (`[src/InfrastructureAsCode/main.bicepL16-R16](diffhunk://#diff-a705772ad6c700e9d296ea9fb26de5e54a731a73bf57caf1f56f6bb3dbed2869L16-R16)`)
* Defined a new Redis Cache resource `redisCache` with the `Basic` SKU. (`[src/InfrastructureAsCode/main.bicepR103-R118](diffhunk://#diff-a705772ad6c700e9d296ea9fb26de5e54a731a73bf57caf1f56f6bb3dbed2869R103-R118)`)
* Updated the outputs to include `redis_cache_name` for the Redis Cache. (`[src/InfrastructureAsCode/main.bicepR103-R118](diffhunk://#diff-a705772ad6c700e9d296ea9fb26de5e54a731a73bf57caf1f56f6bb3dbed2869R103-R118)`)